### PR TITLE
Change inch marks to foot marks in order to print inch mark

### DIFF
--- a/ch07/cubic-bezier.html
+++ b/ch07/cubic-bezier.html
@@ -93,7 +93,7 @@ function updatePaths()
   obj.setAttribute("cy", cp2Y);
   
   path = '&lt;path d="M 40 50 C <span class="cp1">' + cp1X + " " + cp1Y +
-    '</span> <span class="cp2">'  + cp2X + " " + cp2Y + "</span> 110 50/&gt;";
+    '</span> <span class="cp2">'  + cp2X + " " + cp2Y + '</span> 110 50"/&gt;';
   document.getElementById("bezierSource").innerHTML = path;
   
   // Finally, the guide lines


### PR DESCRIPTION
Fix issue in which closing inch marks are not printed, thus creating a syntax error in the `path` example.